### PR TITLE
Default gridrows and gridcols

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -179,8 +179,8 @@ class LayoutCard extends LitElement {
         <div id="staging" class="grid"
         style="
         display: grid;
-        grid-template-rows: ${this._config.gridrows};
-        grid-template-columns: ${this._config.gridcols};
+        grid-template-rows: ${this._config.gridrows || "auto"};
+        grid-template-columns: ${this._config.gridcols || "auto"};
         "></div>
       `;
     return html`


### PR DESCRIPTION
When either `gridrows` or `gridcols` are not specified in the config they end up as `undefined` in the HTML output.