### PR TITLE
`auto` not supported on grid-gap and place-items

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -212,8 +212,8 @@ class LayoutCard extends LitElement {
         display: grid;
         grid-template-rows: ${this._config.gridrows || "auto"};
         grid-template-columns: ${this._config.gridcols || "auto"};
-        grid-gap: ${this._config.gridgap || "auto"};
-        place-items: ${this._config.gridplace || "auto"};
+        ${this._config.gridgap ? `grid-gap: ${this._config.gridgap}` : ""}
+        ${this._config.gridplace ? `place-items: ${this._config.gridplace}` : ""}
         "></div>
       `;
     return html`


### PR DESCRIPTION
FYI, I am using grid layout. Only using `gridcols`, none of the other grid config, and letting grid take care of the rest. Snippit of my config:
```
            - type: custom:layout-card
              layout: grid
              gridcols: 1fr 1fr 1fr
              cards:
                - @%block_label("Kitchen")%@
                - @%block_label("Halls")%@
                - @%block_label("Outdoors")%@
               ...
```
The funky stuff `@%block_label("Kitchen")%@ is Python code processed by a new Python lib I wrote to embed Python code in YAML (https://github.com/gwww/pyaml).