### PR TITLE
[Feature] Adding support for scrollable content

### DIFF
--- a/src/layouts/base-column-layout.ts
+++ b/src/layouts/base-column-layout.ts
@@ -84,8 +84,36 @@ export class BaseColumnLayout extends BaseLayout {
       ? this._config.layout.width * 2
       : 600;
 
+    const scrollable = this._config.layout?.scrollable || false;
+
+    let additionalHostStyles = ``;
+    let stylesOverride = ``;
+
+    if (scrollable) {
+      additionalHostStyles += `
+        max-width:100%;
+        overflow-x:auto;
+      `;
+
+      stylesOverride += css`
+      .column {
+        max-height:85vh;
+        overflow: auto;
+      }
+      `;
+    }
+
+
+    stylesOverride += `
+    #columns {
+      justify-content: ${scrollable ? "start": "center"};
+    }
+  `
+
     const styleEl = document.createElement("style");
     styleEl.innerHTML = `
+      ${stylesOverride}
+
       :host {
         --column-max-width: ${column_max_width}px;
         --column-width: ${column_width}px;
@@ -100,6 +128,7 @@ export class BaseColumnLayout extends BaseLayout {
         --layout-overflow: ${
           this._config.layout?.height !== undefined ? "auto" : "visible"
         };
+        ${additionalHostStyles}
       }
       @media (max-width: ${column_max_width}px) {
         .column:first-child > * {
@@ -128,7 +157,11 @@ export class BaseColumnLayout extends BaseLayout {
   }
 
   async _updateSize() {
-    let width = this.getBoundingClientRect().width;
+    if (this._config.layout?.scrollable) {
+      this._columns = this._config.layout?.max_cols || (this.hass?.dockedSidebar === "docked" ? 3 : 4)
+      return;
+    }
+    let width = this.getBoundingClientRect().width * 3;
     let colnum = 0;
     colnum = Math.floor(width / (this._config.layout?.width || 300));
     colnum = Math.min(
@@ -239,7 +272,7 @@ export class BaseColumnLayout extends BaseLayout {
             var(--column-max-width)
           );
           grid-template-columns: var(--column-widths);
-          justify-content: center;
+          
           justify-items: center;
           margin: var(--layout-margin);
           padding: var(--layout-padding);

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export interface ColumnViewConfig extends ViewConfig {
     padding?: string;
     height?: string;
     reflow?: boolean;
+    scrollable?: boolean;
     width?: number;
     column_widths: string;
     max_width?: number;


### PR DESCRIPTION
Hi everyone,
I wanted to add the ability to scroll-x the content of the cards same as i have in my car (inspiration), this way i can stack a multiple rooms together and and scroll up and down each room.

Having scrollable content makes me feel like more native flow then clicking on multiple tabs.

How does it work ? 
on column based layout add the following config:

`
scrollable: true
max_cols: XX // its will calculate width * max cols to determine the size of scroll
width: 350px // just example or it will be using the default of 300px
`

What if i don't want same size cols ?
just use the `column_widths` property.

Full config example : 
`
width: 350
max_cols: 5
margin: 10px 20px;
padding: 10px
scrollable: true
max_width: 700
column_widths: 350px 700px 350px 350px

`




Inspiration : 



![photo_2022-09-27_20-56-09](https://user-images.githubusercontent.com/275991/193344115-e5b30ac2-e328-43dd-bfd3-6d7e663304f2.jpg)



Final result : 



![photo_2022-09-30_22-38-23](https://user-images.githubusercontent.com/275991/193344307-bfeac0bb-85fa-48e9-8684-f5d961d01c70.jpg)

![photo_2022-09-30_22-39-21](https://user-images.githubusercontent.com/275991/193344485-ae9fe6db-9c2a-45e9-8938-73c1849c7301.jpg)


Thanks.
