### PR TITLE
Don't disable option in view editor

### DIFF
--- a/src/patches/hui-view-editor.ts
+++ b/src/patches/hui-view-editor.ts
@@ -9,7 +9,6 @@ customElements.whenDefined("hui-view-editor").then(() => {
 
     this._oldSchema = this._schema;
     this._schema = (...arg) => {
-      const [_localize, currentType, isNew] = arg;
       const retval = this._oldSchema(...arg);
       const typeSelector = retval.find((e) => e.name == "type");
       if (typeSelector.name === "layout") return retval;
@@ -18,11 +17,9 @@ customElements.whenDefined("hui-view-editor").then(() => {
           (option) => option.value === LAYOUT_CARD_SELECTOR_OPTIONS[0].value
         )
       ) {
-        const options = LAYOUT_CARD_SELECTOR_OPTIONS.map((option) => ({
-          ...option,
-          disabled: currentType === "sections" && isNew === false,
-        }));
-        typeSelector.selector.select.options.push(...options);
+        typeSelector.selector.select.options.push(
+          ...LAYOUT_CARD_SELECTOR_OPTIONS
+        );
       }
 
       if (retval.find((e) => e.name === "layout") === undefined)


### PR DESCRIPTION
Disabling options is not needed anymore as the editor view now use a alert at the top (see attached screenshot).

The `isNew` parameter has been removed in HA front-end so the option will never be disabled. This didn't change something, it's just code cleaning.

![CleanShot 2024-03-20 at 12 31 40](https://github.com/thomasloven/lovelace-layout-card/assets/5878303/c85afbf8-1b71-4443-adcf-8c1bfc697bdf)
