### PR TITLE
Fix display of help text

### DIFF
--- a/src/layout-card-editor.ts
+++ b/src/layout-card-editor.ts
@@ -165,10 +165,7 @@ class LayoutCardEditor extends LitElement {
           href="https://github.com/thomasloven/lovelace-layout-card"
           target="_blank"
           rel="no referrer"
-        >
-          layout-card on github
-        </a>
-        for usage instructions.
+        >layout-card on GitHub</a> for usage instructions.
       </p>
       <ha-form
         .hass=${this.hass}

--- a/src/patches/hui-view-editor.ts
+++ b/src/patches/hui-view-editor.ts
@@ -32,16 +32,13 @@ customElements.whenDefined("hui-view-editor").then(() => {
 
     const helpLink = document.createElement("p");
     helpLink.innerHTML = `
-      You have layout-card installed which adds some options to this dialog. <br/>
+      You have layout-card installed which adds some options to this dialog.<br/>
       Please see
         <a
           href="https://github.com/thomasloven/lovelace-layout-card"
           target="_blank"
           rel="no referrer"
-        >
-          layout-card on github
-        </a>
-        for usage instructions.
+        >layout-card on GitHub</a>for usage instructions.
         <style>
           p {padding: 16px 0 0; margin-bottom: 0;}
           a {color: var(--primary-color);}


### PR DESCRIPTION
<img width="487" height="76" alt="Screenshot 2025-09-24 at 15 21 12" src="https://github.com/user-attachments/assets/330a9cba-e34d-41a7-be50-186730dc9b53" />

^ The link collects part of the trailing space